### PR TITLE
Automatic post generation

### DIFF
--- a/main.php
+++ b/main.php
@@ -42,6 +42,7 @@ class Mashery {
         $parent = self::generate_page("Account", "account", "[mashery:account]");
         self::generate_page("APIs", "apis", "[mashery:apis]", $parent);
         self::generate_page("Applications", "applications", "[mashery:applications]", $parent);
+        self::generate_page("Keys", "keys", "[mashery:keys]", $parent);
     }
 
     function deactivation() {
@@ -52,6 +53,9 @@ class Mashery {
         self::trash_page("account");
         self::trash_page("apis");
         self::trash_page("applications");
+        self::trash_page("keys");
+    }
+
     public function generate_page($title, $name, $content, $parent=0){
         // https://wordpress.org/support/topic/how-do-i-create-a-new-page-with-the-plugin-im-building
         // delete_option("mashery_" . $name . "_page_title");


### PR DESCRIPTION
As per @jpollock 's request... Automatic post generation (#43)!

This change makes the plugin generate certain "recommended" pages on activation. The pages are:
- `account` which contains the `[mashery:account]` shortcode.
- `apis` which contains the `[mashery:apis]` shortcode.
- `applications` which contains the `[mashery:applications]` shortcode.
- `keys` which contains the `[mashery:keys]` shortcode.

The IDs for the generated pages are stored in WP options in the database.

On plugin deactivation the pages are moved to the trash but not deleted. On reactivation the old pages are restored.

The `apis`, `applications` and `keys` pages are all automatically made children of the `account` page.

Users are still able to edit and move the pages as they wish but changing the `name` (which internally is NOT the same as the `title`) will break the deletion/restore process because it looks up the pages by the original names. @cferdinandi if you can think of a better way to handle this, lets discuss it.

Thanks,
